### PR TITLE
finding odex file if classes.dex is missed

### DIFF
--- a/app/src/main/java/com/example/bartman/baksmalihelloworld/BaksmaliAdapter.java
+++ b/app/src/main/java/com/example/bartman/baksmalihelloworld/BaksmaliAdapter.java
@@ -1,7 +1,11 @@
 package com.example.bartman.baksmalihelloworld;
 
-import org.jf.baksmali.main;
+import android.util.Log;
 
+import org.jf.baksmali.main;
+import org.jf.dexlib2.DexFileFactory;
+
+import java.io.File;
 import java.io.IOException;
 
 /**
@@ -22,6 +26,30 @@ public class BaksmaliAdapter {
         } catch (IOException e) {
             e.printStackTrace();
         }
+        catch (DexFileFactory.DexFileNotFound dexFileNotFound){
+            Log.i("odex call",apkPath);
+            doBaksmali(getOdexPath(apkPath),outputPath);
+
+
+        }
 
     }
+    static String getOdexPath(String apkPath){
+        String odexPath = apkPath.substring(0,apkPath.length()-3).concat("odex");
+
+        boolean fileExists =  new File(odexPath).isFile();
+        if (fileExists){
+            return odexPath;
+        }
+        else {
+            String dir = new File(odexPath).getParent();
+            String filename = new File(odexPath).getName();
+            String odexOATPath;
+            odexOATPath = dir.concat("/oat/x86/"+filename);
+            Log.i("paths-filename",filename);
+            return odexOATPath;
+        }
+    }
 }
+
+


### PR DESCRIPTION
answering the issue reported for missing the classes.dex inside the apk which is due to the dalvik optimisation , we added a catch for the exception DexFileNotFound and find the odex file 
 the modifications are only in the BaksmaliAdapeter class 
I wish you merge the modifications in your repository ! 